### PR TITLE
Fix a url pattern so extension load doesn't error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
     "clipboardRead",
     "clipboardWrite",
     "contextMenus",
-    "http*://*/*"
+    "*://*/*"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
I was getting a url error with the old url

https://stackoverflow.com/questions/16096482/what-does-http-https-and-all-urls-mean-in-the-context-of-ch